### PR TITLE
Add support for Kubernetes master load balancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Example for bootstraping a SSL-protected etcd cluster with CoreOS
         - role: "sigma.kubernetes-ca"
           kubernetes_master_group: "masters"
 
+If deploying master nodes in HA configuration, following variables can be specified:
+          kubernetes_master_elb_ip: <MASTER_LOADBALANCER_IP>
+          kubernetes_master_elb_dns_name: <MASTER_LOADBALANCER_DNS_NAME>
+          kubernetes_master_elb_cname: <MASTER_LOADBALANCER_CNAME>
+
 License
 -------
 

--- a/templates/openssl.cnf.j2
+++ b/templates/openssl.cnf.j2
@@ -12,7 +12,17 @@ DNS.2 = kubernetes.default
 DNS.3 = kubernetes.svc
 IP.1 = {{ kubernetes_service_addresses|ipaddr('net')|ipaddr(1)|ipaddr('address') }}
 {% if kubernetes_master_group %}
+{% set ip_last_index = 1 %}
 {% for host in groups[kubernetes_master_group] %}
-IP.{{loop.index + 1}} = {{ hostvars[host].ansible_default_ipv4.address }}
+IP.{{ ip_last_index + loop.index }} = {{ hostvars[host].ansible_default_ipv4.address }}
 {% endfor %}
+{% if kubernetes_master_elb_ip is defined %}
+IP.{{ ip_last_index + 1 + groups[kubernetes_master_group]|length }} = {{ kubernetes_master_elb_ip|ipv4 }}
+{% endif %}
+{% if kubernetes_master_elb_dns_name is defined %}
+DNS.4 = {{ kubernetes_master_elb_dns_name }}
+{% if kubernetes_master_elb_cname is defined %}
+DNS.5 = {{ kubernetes_master_elb_cname }}
+{% endif %}
+{% endif %}
 {% endif %}


### PR DESCRIPTION
- Add Kubernetes master Load Balancer IP, DNS name and alias to
  openssl.cnf for HA.
  https://coreos.com/kubernetes/docs/latest/openssl.html#openssl-config