### PR TITLE
generate certs for api server

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -84,3 +84,34 @@
     -CA {{kubernetes_ca_depot}}/ca.pem -CAkey {{kubernetes_ca_depot}}/ca-key.pem
     -CAcreateserial -out {{kubernetes_ca_depot}}/admin.pem -days 3650
     creates={{kubernetes_ca_depot}}/admin.pem
+
+- name: create client ca key
+  shell: >
+    {{openssl}} genrsa -out {{kubernetes_ca_depot}}/client-ca-key.pem 2048
+    creates={{kubernetes_ca_depot}}/client-ca-key.pem
+
+- name: create client ca pem
+  shell: >
+    {{openssl}} req -x509 -new -nodes -days 10000
+    -key {{kubernetes_ca_depot}}/client-ca-key.pem
+    -out {{kubernetes_ca_depot}}/client-ca.pem
+    -subj "/CN=kube-client-ca"
+    creates={{kubernetes_ca_depot}}/client-ca.pem
+
+- name: generate client key
+  shell: >
+    {{openssl}} genrsa -out {{kubernetes_ca_depot}}/client-key.pem 2048
+    creates={{kubernetes_ca_depot}}/client-key.pem
+
+- name: generate client csr
+  shell: >
+    {{openssl}} req -new -key {{kubernetes_ca_depot}}/client-key.pem
+    -out {{kubernetes_ca_depot}}/client.csr -subj "/CN=apiserver-client"
+    creates={{kubernetes_ca_depot}}/client.csr
+
+- name: generate client crt
+  shell: >
+    {{openssl}} x509 -req -in {{kubernetes_ca_depot}}/client.csr
+    -CA {{kubernetes_ca_depot}}/client-ca.pem -CAkey {{kubernetes_ca_depot}}/client-ca-key.pem
+    -CAcreateserial -out {{kubernetes_ca_depot}}/client.pem -days 3650
+    creates={{kubernetes_ca_depot}}/client.pem


### PR DESCRIPTION
These certs generated will be used by apiserver when it acts like a
client. Apiserver acts like a client in two situations.

1) When it is acting as a proxy for another apiserver. This usecase is
seen for apiserver in relay mode or in apiserver of the federation.
2) Apiserver talking to admission controller webhook.

Our current usecase iss the second option.

Note in case of the webhook ca verification is turned off.